### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,16 +12,16 @@ Filter	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-available   KEYWORD2
-capacity   KEYWORD2
-contains   KEYWORD2
-describe   KEYWORD2
-maximum   KEYWORD2
-mean   KEYWORD2
-median   KEYWORD2
-minimum   KEYWORD2
-resize   KEYWORD2
-stDevPopulation   KEYWORD2
-stDevSample   KEYWORD2
-write   KEYWORD2
+available	KEYWORD2
+capacity	KEYWORD2
+contains	KEYWORD2
+describe	KEYWORD2
+maximum	KEYWORD2
+mean	KEYWORD2
+median	KEYWORD2
+minimum	KEYWORD2
+resize	KEYWORD2
+stDevPopulation	KEYWORD2
+stDevSample	KEYWORD2
+write	KEYWORD2
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords